### PR TITLE
Remove BCH/Fulctrum references from README.md

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,5 +42,5 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Build docker image
-        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t ghcr.io/${{ github.repository_owner }}/FullcrumX -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
+        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t ghcr.io/${{ github.repository_owner }}/fullcrumx -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,5 +42,5 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Build docker image
-        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t ghcr.io/${{ github.repository_owner }}/fullcrumx -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
+        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t ghcr.io/${{ github.repository_owner }}/fulcrumx -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,19 +27,20 @@ jobs:
       - name: Set WORKER_COUNT env
         run: echo "WORKER_COUNT=$(nproc)" >> $GITHUB_ENV
 
-      - name: Login to docker hub
-        uses: docker/login-action@v1.6.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
         with:
-          username: cculianu
-          password: ${{secrets.DOCKERHUB_PASSWORD}}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v1
 
       # If you want support for more platforms you can use our setup-qemu action:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - name: Create buildx worker node
-        run: docker buildx create --use
-
       - name: Build docker image
-        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t cculianu/fulcrum -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
+        run: docker buildx build --build-arg MAKEFLAGS="-j ${WORKER_COUNT}" -t ghcr.io/${{ github.repository_owner }}/FullcrumX -f contrib/docker/Dockerfile --platform linux/arm64/v8,linux/amd64 --push .
 

--- a/FulcrumX.pro
+++ b/FulcrumX.pro
@@ -1,6 +1,7 @@
 #
-# Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+# FulcrumX - A fast & nimble SPV Server for Bitcoin
 # Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+# Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,7 +36,7 @@ CONFIG += c++17 console warn_on
 CONFIG -= app_bundle
 
 versionAtMost(QT_VERSION, 5.12.4) {
-    error("Fulcrum requires Qt 5.12.5 (or later) or Qt 5.13.1 (or later) to be successfully built without errors.  Please use Qt 5.12.5+ or Qt 5.13.1+ to build this codebase.")
+    error("FulcrumX requires Qt 5.12.5 (or later) or Qt 5.13.1 (or later) to be successfully built without errors.  Please use Qt 5.12.5+ or Qt 5.13.1+ to build this codebase.")
 }
 
 QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
@@ -205,7 +206,7 @@ contains(CONFIG, config_endian_big) {
         #   - Build with this command:
         #         mingw32-make -j4 V=1 rocksdb  <-- will build static lib only
         #   The generated librocksdb.a will be in the build/ directory you are currently in, ready to be put into the
-        #   Fulcrum directory staticlibs/rocksdb/bin/win64.
+        #   FulcrumX directory staticlibs/rocksdb/bin/win64.
         macx {
             LIBS += -L$$PWD/staticlibs/rocksdb/bin/osx
         }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
-Fulcrum - A fast & nimble SPV Server for Electron Cash
-Copyright (C) 2019-2021  Calin A. Culianu <calin.culianu@gmail.com>
+FulcrumX - A fast & nimble SPV Server for Electron Cash
+Copyright (C) 2019-2022  Calin A. Culianu <calin.culianu@gmail.com>
+Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# Fulcrum
+# FulcrumX
 
-[![Travis CI Build](https://img.shields.io/travis/cculianu/Fulcrum/master)](https://travis-ci.org/cculianu/Fulcrum)
-[![Docker Build](https://github.com/cculianu/Fulcrum/actions/workflows/publish.yml/badge.svg)](https://github.com/cculianu/Fulcrum/actions/workflows/publish.yml)
-[![Copr build status](https://copr.fedorainfracloud.org/coprs/jonny/BitcoinCash/package/fulcrum/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/jonny/BitcoinCash/package/fulcrum/)
+A fast & nimble SPV server for Bitcoin.
 
-A fast & nimble SPV server for Bitcoin Cash & Bitcoin BTC.
+This is a fork of the original Fulcrum focused on only keeping the original Bitcoin.
+
+This has the following advantages over a version with Bitcoin Cash support:
+
+- More easily auditable code
+- Smaller binaries
+
+All other improvements in FulcrumX will be contributed upstream.
 
 #### Copyright
 (C) 2019-2022 Calin Culianu <calin.culianu@gmail.com>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This has the following advantages over a version with Bitcoin Cash support:
 All other improvements in FulcrumX will be contributed upstream.
 
 #### Copyright
+
 (C) 2019-2022 Calin Culianu <calin.culianu@gmail.com>
+(C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 
 #### License:
 GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the license](https://www.gnu.org/licenses/gpl-3.0.html).

--- a/README.md
+++ b/README.md
@@ -25,29 +25,29 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
 ### Highlights:
 
 - *Fast:* Written in 100% modern `C++17` using multi-threaded and asynchronous programming techniques.
-- *A drop-in replacement for ElectronX/ElectrumX:* Fulcrum is 100% protocol-level compatible with the [Electrum Cash 1.4.5 protocol](https://electrum-cash-protocol.readthedocs.io/en/latest/). Existing server admins should feel right at home with this software since installation and management of it is nearly identical to ElectronX/ElectrumX server.
+- *A drop-in replacement for ElectrumX:* FulcrumX is 100% protocol-level compatible with the [Electrum protocol](https://electrumx.readthedocs.io/en/latest/protocol.html). Existing server admins should feel right at home with this software since installation and management of it is nearly identical to ElectronX/ElectrumX server.
 - *Cross-platform:* While this codebase was mainly developed and tested on MacOS, Windows and Linux, it should theoretically work on any modern OS (such as *BSD) that has Qt5 Core and Qt5 Networking available.
 
 ### Requirements
 
 - *For running*:
   - A supported bitcoin full node with its JSON-RPC service enabled, preferably running on the same machine.
-    - *For **BTC***: Bitcoin Core v0.17.0 or later. Bitcoin Knots is also supported. BTCD has not yet been tested.
+    - Bitcoin Core v0.17.0 or later. Bitcoin Knots is also supported. BTCD has not yet been tested.
     - The node must have txindex enabled e.g. `txindex=1`.
     - The node must not be a pruning node.
-    - *Optional*: For best results, enable zmq for the "hasblock" topic using e.g. `zmqpubhashblock=tcp://0.0.0.0:8433` in your `bitcoin.conf` file (zmq is only available on: Core, BCHN, or BU 1.9.1+).
-  - *Recommended hardware*: Minimum 1GB RAM, 64-bit CPU, ~40GB disk space for mainnet BCH (slightly more for BTC). For best results, use an SSD rather than an HDD.
+    - *Optional*: For best results, enable zmq for the "hasblock" topic using e.g. `zmqpubhashblock=tcp://0.0.0.0:8433` in your `bitcoin.conf` file (zmq is only available on Core).
+  - *Recommended hardware*: Minimum 1GB RAM, 64-bit CPU, ~50GB disk space for mainnet BTC. For best results, use an SSD rather than an HDD.
 - *For compiling*: 
   - `Qt Core` & `Qt Networking` libraries `5.12.5` or above (I use `5.15.2` myself).  Qt `5.12.4` (or earlier) is not supported.
-  - *Optional but recommended*: `libzmq 4.x` development headers and library (also known as `libzmq3-dev` on Debian/Ubuntu and `zeromq-devel` on Fedora). Fulcrum will run just fine without linking against `libzmq`, but it will run better if you do link against `libzmq` and also turn on `zmqpubhashblock` notifications in `bitcoind` (zmq is only available on: Core, BCHN, or BU 1.9.1+).
+  - *Optional but recommended*: `libzmq 4.x` development headers and library (also known as `libzmq3-dev` on Debian/Ubuntu and `zeromq-devel` on Fedora). FulcrumX will run just fine without linking against `libzmq`, but it will run better if you do link against `libzmq` and also turn on `zmqpubhashblock` notifications in `bitcoind` (zmq is only available on Core).
   - A modern, 64-bit `C++17` compiler.  `clang` is recommended but `G++` also works. MSVC on Windows is not supported (please use `MinGW G++` instead, which ships with Qt Open Source Edition for Windows).
 
 ### Quickstart
 
 1. Download a [pre-built static binary](https://github.com/runcitadel/FulcrumX/releases).
-2. Verify that the binary runs on your system by executing the binary with `./Fulcrum -h` to see the CLI options.
-3. Setup a configuration file and to point Fulcrum to your bitcoind JSON-RPC server, specify listening ports, TLS certificates, etc.  See: [doc/fulcrum-example-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-example-config.conf) and/or [doc/fulcrum-quick-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-quick-config.conf)
-4. Also see this section below on [Running Fulcrum](#running-fulcrum).
+2. Verify that the binary runs on your system by executing the binary with `./FulcrumX -h` to see the CLI options.
+3. Setup a configuration file and to point FulcrumX to your bitcoind JSON-RPC server, specify listening ports, TLS certificates, etc.  See: [doc/fulcrum-example-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-example-config.conf) and/or [doc/fulcrum-quick-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-quick-config.conf)
+4. Also see this section below on [Running FulcrumX](#running-fulcrum).
 
 ### How To Compile
 
@@ -70,7 +70,7 @@ You may also build from the CLI (on Linux and MacOS):
 #### What to do if compiling fails
 If you have problems compiling, the most likely culprit would be your compiler not being `C++17` compliant (please use a recent verson of `GCC` or `clang` on Linux, Apple's `Xcode` on Mac, or `MinGW G++ 7.x` on Windows).
 
-The other likely culprit is the fact that at the present time I have included a statically-built `librocksdb` in the codebase. There are versions of this library for Windows, Mac, and Linux included right in the source tree, and `Fulcrum.pro` looks for them and links to them. Instructions are included within the `Fulcrum.pro` project file about how to build your own static `librocksdb` if the bundled one does not work on your system.
+The other likely culprit is the fact that at the present time I have included a statically-built `librocksdb` in the codebase. There are versions of this library for Windows, Mac, and Linux included right in the source tree, and `FulcrumX.pro` looks for them and links to them. Instructions are included within the `FulcrumX.pro` project file about how to build your own static `librocksdb` if the bundled one does not work on your system.
 
 If you are still having trouble, [file an issue here in this github](https://github.com/runcitadel/FulcrumX/issues).
 
@@ -87,7 +87,7 @@ You may optionally build against the **system rocksdb** (Linux only) if your dis
 
 Ensure that `libzmq3` (Debian/Ubuntu) and/or `zeromq-devel` (Fedora/Redhat) is installed, and that `pkg-config` is also installed.  If on Unix (macOS, Linux, or Windows MinGW), then ideally the `qmake` step will find `libzmq` on your system and automatically use it. If that is not the case, you may try passing flags to `qmake` such as `LIBS+="-L/path/to/libdir_containting_libzmq -lzmq"` and `INCLUDEPATH+="/path/to/dir_containing_zmq_h"` as arguments when you invoke `qmake`.  Using `libzmq` is optional but highly recommended. If you have trouble getting Fulcrum to compile against your `libzmq`, [open a new issue](https://github.com/runcitadel/FulcrumX/issues) and maybe I can help.
 
-### Building the Windows static `Fulcrum.exe`
+### Building the Windows static `FulcrumX.exe`
 
 **New!** I recently added a mechanism using Docker to build a statically-linked
 Windows `.exe`. This build is 100% compatible with any stock 64-bit Windows 7 or
@@ -109,7 +109,7 @@ As such, it may take a while so be patient.
 
 The first argument to the script is the platform to build (in this case
 `windows`). The second argument to the script is a git `branch` or `tag` to
-build. Two `.exe` files will be generated, `Fulcrum.exe` and `FulcrumAdmin.exe`,
+build. Two `.exe` files will be generated, `FulcrumX.exe` and `FulcrumAdmin.exe`,
 which will appear in `dist/win` after the build process completes.
 
 - *Note:* You can point the build script to any repository, not just this one, by giving it a `GIT_REPO` environment variable:
@@ -156,7 +156,7 @@ Execute the binary, with `-h` to see the built-in help, e.g. `./FulcrumX -h`. Yo
  - [doc/fulcrum-example-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-example-config.conf) in the source tree. This sample config file is very well documented with comments.
  - [doc/fulcrum-quick-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-quick-config.conf) in the source tree. This is a more abbreviated config file you can use as a starting point as well.
 
-`Fulcrum` requires a `bitcoind` instance running either on `testnet` or `mainnet` (or `regtest` for testing), which you must tell it about via the CLI options or via the config file.  You also need to tell it what port(s) to listen on and optionally what SSL certificates to use (if using SSL).
+`FulcrumX` requires a `bitcoind` instance running either on `testnet` or `mainnet` (or `regtest` for testing), which you must tell it about via the CLI options or via the config file.  You also need to tell it what port(s) to listen on and optionally what SSL certificates to use (if using SSL).
 
 It is recommended you specify a data dir (`-D` via CLI or `datadir=` via config file) on an SSD drive for best results.  Synching against `testnet` should take you about 10-20 minutes (more on slower machines), and mainnet can take anywhere from 4 hours to 20+ hours, depending on machine and drive speed.  I have not tried synching against mainnet on an HDD and it will probably take ***days*** if you are lucky.
 
@@ -167,7 +167,7 @@ You may also wish to read the [FulcrumX manpage](https://github.com/runcitadel/F
 
 #### Admin Script: FulcrumAdmin
 
-`Fulcrum` comes with an admin script (`Python 3.6+` is required on the system to run this script).  You may send commands to `Fulcrum` using this script. The script requires that an **admin port** (config var `admin=`, CLI arg `-a`) be configured for your server.  To run the script, execute `./FulcrumAdmin -h` and you will see a list of possible subcommands that you can send to `Fulcrum`.  Here are two of the most popular commands to try (the below assumes the `admin` port is on port `8000`):
+`FulcrumX` comes with an admin script (`Python 3.6+` is required on the system to run this script).  You may send commands to `FulcrumX` using this script. The script requires that an **admin port** (config var `admin=`, CLI arg `-a`) be configured for your server.  To run the script, execute `./FulcrumAdmin -h` and you will see a list of possible subcommands that you can send to `FulcrumX`.  Here are two of the most popular commands to try (the below assumes the `admin` port is on port `8000`):
 
     $ ./FulcrumAdmin -p 8000 peers
     $ ./FulcrumAdmin -p 8000 clients
@@ -208,6 +208,6 @@ Everything should just work (I use MacOS as my dev machine).
 
 **A:** Yes, I know.  However, Qt is a very robust, cross-platform and fast application framework.  You can use its "Core" library for console apps, servers, etc.  It has great network support and other basic things a programmer needs to get stuff done.
 
-**Q:** Why is the compiled binary called `Fulcrum` (capital `F`) and not `fulcrum` (lowercase `f`) as is customary on Linux/Unix?
+**Q:** Why is the compiled binary called `FulcrumX` (capital `F`) and not `fulcrum` (lowercase `f`) as is customary on Linux/Unix?
 
 **A:** Because I like capital letters, even on Linux.  I also develop (this and other software) for macOS and Windows and over there the Linux/Unix lowecase thing looks a little out-of-place.  Perhaps my sensibilities have been affected by my win32 and macOS dev work, or perhaps I'm just unconventional.  Embrace the lack of convention here! That being said, if the capital `F` bothers you, feel free to rename it or represent it as `fulcrum` wherever you like.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All other improvements in FulcrumX will be contributed upstream.
 #### Copyright
 
 (C) 2019-2022 Calin Culianu <calin.culianu@gmail.com>
+
 (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 
 #### License:

--- a/README.md
+++ b/README.md
@@ -26,14 +26,12 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
 - *Fast:* Written in 100% modern `C++17` using multi-threaded and asynchronous programming techniques.
 - *A drop-in replacement for ElectronX/ElectrumX:* Fulcrum is 100% protocol-level compatible with the [Electrum Cash 1.4.5 protocol](https://electrum-cash-protocol.readthedocs.io/en/latest/). Existing server admins should feel right at home with this software since installation and management of it is nearly identical to ElectronX/ElectrumX server.
 - *Cross-platform:* While this codebase was mainly developed and tested on MacOS, Windows and Linux, it should theoretically work on any modern OS (such as *BSD) that has Qt5 Core and Qt5 Networking available.
-- ***NEW!*** *Dual-coin:* Supports both BCH and BTC.
 
 ### Requirements
 
 - *For running*:
   - A supported bitcoin full node with its JSON-RPC service enabled, preferably running on the same machine.
-    - *For **BCH***: Bitcoin Cash Node, Bitcoin Unlimited Cash, Flowee, and bchd have all been tested extensively and are known to work well with this software.
-    - *For **BTC***: Bitcoin Core v0.17.0 or later.  No other full nodes are supported by this software for BTC.
+    - *For **BTC***: Bitcoin Core v0.17.0 or later. Bitcoin Knots is also supported. BTCD has not yet been tested.
     - The node must have txindex enabled e.g. `txindex=1`.
     - The node must not be a pruning node.
     - *Optional*: For best results, enable zmq for the "hasblock" topic using e.g. `zmqpubhashblock=tcp://0.0.0.0:8433` in your `bitcoin.conf` file (zmq is only available on: Core, BCHN, or BU 1.9.1+).
@@ -45,14 +43,14 @@ GPLv3. See the included `LICENSE.txt` file or [visit gnu.org and read the licens
 
 ### Quickstart
 
-1. Download a [pre-built static binary](https://github.com/cculianu/Fulcrum/releases).
+1. Download a [pre-built static binary](https://github.com/runcitadel/FulcrumX/releases).
 2. Verify that the binary runs on your system by executing the binary with `./Fulcrum -h` to see the CLI options.
-3. Setup a configuration file and to point Fulcrum to your bitcoind JSON-RPC server, specify listening ports, TLS certificates, etc.  See: [doc/fulcrum-example-config.conf](https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf) and/or [doc/fulcrum-quick-config.conf](https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-quick-config.conf)
+3. Setup a configuration file and to point Fulcrum to your bitcoind JSON-RPC server, specify listening ports, TLS certificates, etc.  See: [doc/fulcrum-example-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-example-config.conf) and/or [doc/fulcrum-quick-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-quick-config.conf)
 4. Also see this section below on [Running Fulcrum](#running-fulcrum).
 
 ### How To Compile
 
-Compiling is for those users that do not wish to use the [pre-built static binaries provided here](https://github.com/cculianu/Fulcrum/releases), or for users on platforms for which the static binaries are not provided (such as FreeBSD or macOS). To compile, it's recommended you use the Qt Creator IDE.
+Compiling is for those users that do not wish to use the [pre-built static binaries provided here](https://github.com/runcitadel/FulcrumX/releases), or for users on platforms for which the static binaries are not provided (such as FreeBSD or macOS). To compile, it's recommended you use the Qt Creator IDE.
 
 1. Get the latest version of Qt Open Source Edition for your platform.
 2. Point the Qt Creator IDE at the `Fulcrum.pro` file.
@@ -73,7 +71,7 @@ If you have problems compiling, the most likely culprit would be your compiler n
 
 The other likely culprit is the fact that at the present time I have included a statically-built `librocksdb` in the codebase. There are versions of this library for Windows, Mac, and Linux included right in the source tree, and `Fulcrum.pro` looks for them and links to them. Instructions are included within the `Fulcrum.pro` project file about how to build your own static `librocksdb` if the bundled one does not work on your system.
 
-If you are still having trouble, [file an issue here in this github](https://github.com/cculianu/Fulcrum/issues).
+If you are still having trouble, [file an issue here in this github](https://github.com/runcitadel/FulcrumX/issues).
 
 #### Linking against the system `librocksdb.so` (experimental)
 
@@ -86,7 +84,7 @@ You may optionally build against the **system rocksdb** (Linux only) if your dis
 
 #### Making sure `libzmq` is detected and used (optional but recommended)
 
-Ensure that `libzmq3` (Debian/Ubuntu) and/or `zeromq-devel` (Fedora/Redhat) is installed, and that `pkg-config` is also installed.  If on Unix (macOS, Linux, or Windows MinGW), then ideally the `qmake` step will find `libzmq` on your system and automatically use it. If that is not the case, you may try passing flags to `qmake` such as `LIBS+="-L/path/to/libdir_containting_libzmq -lzmq"` and `INCLUDEPATH+="/path/to/dir_containing_zmq_h"` as arguments when you invoke `qmake`.  Using `libzmq` is optional but highly recommended. If you have trouble getting Fulcrum to compile against your `libzmq`, [open a new issue](https://github.com/cculianu/Fulcrum/issues) and maybe I can help.
+Ensure that `libzmq3` (Debian/Ubuntu) and/or `zeromq-devel` (Fedora/Redhat) is installed, and that `pkg-config` is also installed.  If on Unix (macOS, Linux, or Windows MinGW), then ideally the `qmake` step will find `libzmq` on your system and automatically use it. If that is not the case, you may try passing flags to `qmake` such as `LIBS+="-L/path/to/libdir_containting_libzmq -lzmq"` and `INCLUDEPATH+="/path/to/dir_containing_zmq_h"` as arguments when you invoke `qmake`.  Using `libzmq` is optional but highly recommended. If you have trouble getting Fulcrum to compile against your `libzmq`, [open a new issue](https://github.com/runcitadel/FulcrumX/issues) and maybe I can help.
 
 ### Building the Windows static `Fulcrum.exe`
 
@@ -94,7 +92,7 @@ Ensure that `libzmq3` (Debian/Ubuntu) and/or `zeromq-devel` (Fedora/Redhat) is i
 Windows `.exe`. This build is 100% compatible with any stock 64-bit Windows 7 or
 above system -- you don't have to install anything -- it *just works*. You can
 download the pre-built `.exe` yourself here from the [releases
-page](https://github.com/cculianu/Fulcrum/releases).
+page](https://github.com/runcitadel/FulcrumX/releases).
 
 If you want to build it yourself though, you can do so, but it requires
 [Docker](https://www.docker.com/) on either a MacOS or a Linux host system (it
@@ -125,7 +123,7 @@ which will appear in `dist/win` after the build process completes.
 Linux executable. This build is 100% compatible with most stock 64-bit Linux
 systems with a new enough glibc and libstdc++. So on a relatively modern Linux system, you
 don't have to install anything -- it *just works*. You can download the
-pre-built binary yourself here from the [releases page](https://github.com/cculianu/Fulcrum/releases).
+pre-built binary yourself here from the [releases page](https://github.com/runcitadel/FulcrumX/releases).
 
 If you want to build it yourself though, you can do so, but it requires [Docker](https://www.docker.com/)
 on either a MacOS or a Linux host system.  It builds a static Qt and static rocksdb.
@@ -150,20 +148,20 @@ script is a git `branch` or `tag` to build.
 
 ---
 
-### Running Fulcrum
+### Running FulcrumX
 
-Execute the binary, with `-h` to see the built-in help, e.g. `./Fulcrum -h`. You can set most options from the CLI, but you can also specify a **config file** as an argument. See:
+Execute the binary, with `-h` to see the built-in help, e.g. `./FulcrumX -h`. You can set most options from the CLI, but you can also specify a **config file** as an argument. See:
 
- - [doc/fulcrum-example-config.conf](https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf) in the source tree. This sample config file is very well documented with comments.
- - [doc/fulcrum-quick-config.conf](https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-quick-config.conf) in the source tree. This is a more abbreviated config file you can use as a starting point as well.
+ - [doc/fulcrum-example-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-example-config.conf) in the source tree. This sample config file is very well documented with comments.
+ - [doc/fulcrum-quick-config.conf](https://github.com/runcitadel/FulcrumX/blob/master/doc/fulcrum-quick-config.conf) in the source tree. This is a more abbreviated config file you can use as a starting point as well.
 
-`Fulcrum` requires a `bitcoind` instance running either on `testnet` or `mainnet` (or `regtest` for testing), which you must tell it about via the CLI options or via the config file.  You also need to tell it what port(s) to listen on and optionally what SSL certificates to use (if using SSL). ***Note:*** *Electron Cash (and/or Electrum) at this time no longer support connecting to non-SSL servers, so you should probably configure SSL for production use*.
+`Fulcrum` requires a `bitcoind` instance running either on `testnet` or `mainnet` (or `regtest` for testing), which you must tell it about via the CLI options or via the config file.  You also need to tell it what port(s) to listen on and optionally what SSL certificates to use (if using SSL).
 
 It is recommended you specify a data dir (`-D` via CLI or `datadir=` via config file) on an SSD drive for best results.  Synching against `testnet` should take you about 10-20 minutes (more on slower machines), and mainnet can take anywhere from 4 hours to 20+ hours, depending on machine and drive speed.  I have not tried synching against mainnet on an HDD and it will probably take ***days*** if you are lucky.
 
-Once the server finishes synching it will behave like an ElectronX/ElectrumX server and it can receive requests from Electron Cash (or Electrum if on BTC).
+Once the server finishes synching it will behave like an ElectronX/ElectrumX server and it can receive requests from Electrum.
 
-You may also wish to read the [Fulcrum manpage](https://github.com/cculianu/Fulcrum/blob/master/doc/unix-man-page.md).
+You may also wish to read the [FulcrumX manpage](https://github.com/runcitadel/FulcrumX/blob/master/doc/unix-man-page.md).
 
 
 #### Admin Script: FulcrumAdmin
@@ -175,12 +173,6 @@ You may also wish to read the [Fulcrum manpage](https://github.com/cculianu/Fulc
     $ ./FulcrumAdmin -p 8000 getinfo
 
 ***(This section is incomplete for now, all apologies -- more documentation is coming soon!)***
-
----
-
-### Protocol Documentation
-
-Documentation for the Electrum Cash protocol that Fulcrum uses is [available here](https://electrum-cash-protocol.readthedocs.io/en/latest/).
 
 ---
 
@@ -218,21 +210,3 @@ Everything should just work (I use MacOS as my dev machine).
 **Q:** Why is the compiled binary called `Fulcrum` (capital `F`) and not `fulcrum` (lowercase `f`) as is customary on Linux/Unix?
 
 **A:** Because I like capital letters, even on Linux.  I also develop (this and other software) for macOS and Windows and over there the Linux/Unix lowecase thing looks a little out-of-place.  Perhaps my sensibilities have been affected by my win32 and macOS dev work, or perhaps I'm just unconventional.  Embrace the lack of convention here! That being said, if the capital `F` bothers you, feel free to rename it or represent it as `fulcrum` wherever you like.
-
----
-
-### Donations
-
-Sure!  Send **BCH** here:
-
-[bitcoincash:qphax4s4n9h60jxj2fkrjs35w2tvgd4wzvf52cgtzc](bitcoincash:qphax4s4n9h60jxj2fkrjs35w2tvgd4wzvf52cgtzc)
-
-[![bitcoincash:qphax4s4n9h60jxj2fkrjs35w2tvgd4wzvf52cgtzc](https://raw.githubusercontent.com/cculianu/DonateSpareChange/master/donate.png)](bitcoincash:qphax4s4n9h60jxj2fkrjs35w2tvgd4wzvf52cgtzc)
-
-You may also send **BTC** to the BTC-equivalent of the above address, which is: **`1BCHBCH6TXBaXyc5HReLBm1sNytBF2kkPD`**
-
----
-
-### Sponsors
-
-![General Protocols](https://c3-soft.com/imgs/general-protocols.png)

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,26 +1,25 @@
-FROM ubuntu:bionic
-LABEL maintainer="Axel Gembe <derago@gmail.com>"
+FROM debian:bullseye as builder
 
 ARG MAKEFLAGS
 
-RUN apt-get update -y && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:mainnet-pat/opt-qt-5.13.2-bionic && \
-    apt-get update -y && \
-    apt-get install -y qt513base openssl && \
-    apt-get install -y git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libjemalloc1 libzmq3-dev && \
+RUN apt update -y && \
+    apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libjemalloc1 libzmq3-dev qtbase5-dev qt5-qmake qt5-default
+
+WORKDIR /src
+
+COPY . .
+
+RUN qmake -makefile PREFIX=/usr FulcrumX.pro && \
+    make $MAKEFLAGS install
+
+FROM debian:bullseye-slim
+
+RUN apt update && \
+    apt install -y libqt5network5 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY . /src
-
-RUN cd /src && \
-    /opt/qt513/bin/qmake -makefile PREFIX=/usr Fulcrum.pro && \
-    make $MAKEFLAGS install
-
-RUN rm -rf /src && \
-    apt-get remove -y git build-essential zlib1g-dev libbz2-dev libjemalloc-dev && \
-    apt-get autoremove -y
+COPY --from=builder /src/FulcrumX /usr/bin/FulcrumX
 
 VOLUME ["/data"]
 ENV DATA_DIR /data
@@ -33,4 +32,4 @@ EXPOSE 50001 50002
 COPY contrib/docker/docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["Fulcrum"]
+CMD ["FulcrumX"]

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye as builder
 ARG MAKEFLAGS
 
 RUN apt update -y && \
-    apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libzmq3-dev qtbase5-dev qt5-qmake qt5-default
+    apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libzmq3-dev qtbase5-dev qt5-qmake
 
 WORKDIR /src
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye as builder
 ARG MAKEFLAGS
 
 RUN apt update -y && \
-    apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libjemalloc1 libzmq3-dev qtbase5-dev qt5-qmake qt5-default
+    apt install -y openssl git build-essential pkg-config zlib1g-dev libbz2-dev libjemalloc-dev libzmq3-dev qtbase5-dev qt5-qmake qt5-default
 
 WORKDIR /src
 
@@ -15,7 +15,7 @@ RUN qmake -makefile PREFIX=/usr FulcrumX.pro && \
 FROM debian:bullseye-slim
 
 RUN apt update && \
-    apt install -y libqt5network5 && \
+    apt install -y openssl libqt5network5 zlib1g libbz2-1.0 libjemalloc2 libzmq5 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 if [ ! -e "$SSL_CERTFILE" ] || [ ! -e "$SSL_KEYFILE" ] ; then
-  openssl req -newkey rsa:2048 -sha256 -nodes -x509 -days 365 -subj "/O=Fulcrum" -keyout "$SSL_KEYFILE" -out "$SSL_CERTFILE"
+  openssl req -newkey rsa:2048 -sha256 -nodes -x509 -days 365 -subj "/O=FulcrumX" -keyout "$SSL_KEYFILE" -out "$SSL_CERTFILE"
 fi
 
-if [ "$1" = "Fulcrum" ] ; then
+if [ "$1" = "FulcrumX" ] ; then
   set -- "$@" -D "$DATA_DIR" -c "$SSL_CERTFILE" -k "$SSL_KEYFILE"
 fi
 

--- a/doc/fulcrum-example-config.conf
+++ b/doc/fulcrum-example-config.conf
@@ -283,7 +283,7 @@ rpcpassword = hunter1
 
 
 # Donation address - 'donation'
-# - DEFAULT: bitcoincash:qplw0d304x9fshz420lkvys2jxup38m9symky6k028
+# - DEFAULT: 1BCHBCH6TXBaXyc5HReLBm1sNytBF2kkPD
 #
 # The server donation address. This address is given to users when they select
 # "Help -> Donate to server" from the Electron Cash GUI, and/or clients that
@@ -295,7 +295,7 @@ rpcpassword = hunter1
 #
 # If unspecified, the default will be the developer's donation address.
 #
-#donation = bitcoincash:qplw0d304x9fshz420lkvys2jxup38m9symky6k028
+#donation = 1BCHBCH6TXBaXyc5HReLBm1sNytBF2kkPD
 
 
 # Server banner text file - 'banner'

--- a/src/AbstractConnection.cpp
+++ b/src/AbstractConnection.cpp
@@ -217,7 +217,7 @@ void AbstractConnection::on_connected()
     connectedConns.push_back(
         connect(socket, &QAbstractSocket::disconnected, this, [this]{
             DebugM(prettyName(), " socket disconnected");
-            for (const auto & connection : connectedConns) {
+            for (const auto & connection : qAsConst(connectedConns)) {
                 QObject::disconnect(connection);
             }
             connectedConns.clear(); // be sure to empty the list out when we are done!

--- a/src/AbstractConnection.cpp
+++ b/src/AbstractConnection.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/AbstractConnection.h
+++ b/src/AbstractConnection.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -260,7 +260,7 @@ void App::startup()
             const auto num = options->statsInterfaces.count();
             Log() << "Stats HTTP: starting " << num << " " << Util::Pluralize("server", num) << " ...";
             // start 'stats' http servers, if any
-            for (const auto & i : options->statsInterfaces)
+            for (const auto & i : qAsConst(options->statsInterfaces))
                 start_httpServer(i); // may throw
         }
 
@@ -276,7 +276,7 @@ void App::cleanup()
     cleanup_WaitForThreadPoolWorkers();
     if (!httpServers.isEmpty()) {
         Log("Stopping Stats HTTP Servers ...");
-        for (auto h : httpServers) { h->stop(); }
+        for (const auto &h : qAsConst(httpServers)) { h->stop(); }
         httpServers.clear(); // deletes shared pointers
     }
     if (controller) { Log("Stopping Controller ... "); controller->cleanup(); controller.reset(); }
@@ -577,7 +577,7 @@ void App::parseArgs()
                 Log() << "Running all " << vals.count() << " tests ...";
             }
             // process tests and exit if we take this branch
-            for (const auto & tname : vals) {
+            for (const auto & tname : qAsConst(vals)) {
                 auto it = registeredTests->find(tname);
                 if (it == registeredTests->end())
                     throw BadArgs(QString("No such test: %1").arg(tname));
@@ -595,7 +595,7 @@ void App::parseArgs()
                 Log() << "Running all " << vals.count() << " benchmarks ...";
             }
             // process benches and exit if we take this branch
-            for (const auto & tname : vals) {
+            for (const auto & tname : qAsConst(vals)) {
                 auto it = registeredBenches->find(tname);
                 if (it == registeredBenches->end())
                     throw BadArgs(QString("No such bench: %1").arg(tname));
@@ -630,7 +630,7 @@ void App::parseArgs()
     }
 
     // first warn user about dupes
-    for (const auto & opt : allOptions) {
+    for (const auto & opt : qAsConst(allOptions)) {
         static const auto DupeMsg = [](const QString &arg) {
             Log() << "'" << arg << "' specified both via the CLI and the configuration file. The CLI arg will take precedence.";
         };
@@ -854,7 +854,7 @@ void App::parseArgs()
                                               ? conf.values("admin")
                                               : parser.values("a"), true);
     // warn user if any of the admin rpc services are on non-loopback
-    for (const auto &iface : options->adminInterfaces) {
+    for (const auto &iface : qAsConst(options->adminInterfaces)) {
         if (!iface.first.isLoopback()) {
             // print the warning later when logger is up
             Util::AsyncOnObject(this, [iface]{

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -866,7 +866,6 @@ void App::parseArgs()
     /// misc conf-only variables ...
     if (conf.hasValue("donation")) {
         options->donationAddress = conf.value("donation", options->donationAddress).left(80); // the 80 character limit is in case the user specified a crazy long string, no need to send all of it -- it's probably invalid anyway.
-        options->isDefaultDonationAddress = false; // turns off the auto-transform mechanism for the author's address.
     }
     options->bannerFile = conf.value("banner", options->bannerFile);
     if (conf.hasValue("hostname"))

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -311,7 +311,7 @@ void App::cleanup_WaitForThreadPoolWorkers()
 void App::parseArgs()
 {
     QCommandLineParser parser;
-    parser.setApplicationDescription("A Bitcoin Cash (and Bitcoin BTC) Blockchain SPV Server");
+    parser.setApplicationDescription("A Bitcoin Blockchain SPV Server");
     parser.addHelpOption();
 
     static constexpr auto RPCUSER = "RPCUSER", RPCPASSWORD = "RPCPASSWORD"; // optional env vars we use below

--- a/src/App.h
+++ b/src/App.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -183,11 +183,10 @@ namespace BTC
         return nameNetMap.value(name, Net::Invalid /* default if not found */);
     }
 
-    namespace { const QString coinNameBCH{"BCH"}, coinNameBTC{"BTC"}; }
+    namespace { const QString coinNameBTC{"BTC"}; }
     QString coinToName(Coin c) {
         QString ret; // for NRVO
         switch (c) {
-        case Coin::BCH: ret = coinNameBCH; break;
         case Coin::BTC: ret = coinNameBTC; break;
         case Coin::Unknown: break;
         }

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -193,8 +193,7 @@ namespace BTC
         return ret;
     }
     Coin coinFromName(const QString &s) {
-        if (s == coinNameBTC) return Coin::BTC;
-        return Coin::Unknown;
+        return Coin::BTC;
     }
 
 } // end namespace BTC

--- a/src/BTC.cpp
+++ b/src/BTC.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BTC_Address.cpp
+++ b/src/BTC_Address.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BTC_Address.h
+++ b/src/BTC_Address.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -235,9 +235,7 @@ void BitcoinDMgr::refreshBitcoinDNetworkInfo()
                 bitcoinDInfo.relayFee = networkInfo.value("relayfee", 0.0).toDouble();
                 bitcoinDInfo.warnings = networkInfo.value("warnings", "").toString();
             } // end lock scope
-            // be sure to announce whether remote bitcoind is bitcoin core (this determines whether we use segwit or not)
-            emit bitcoinCoreDetection(res.isCore);
-            // next, be sure to set up the ping time appropriately for bchd vs bitcoind
+            // next, be sure to set up the ping time appropriately
             resetPingTimers(int(PingTimes::Normal));
             // next up, do this query
             refreshBitcoinDGenesisHash();
@@ -377,12 +375,6 @@ BitcoinDInfo BitcoinDMgr::getBitcoinDInfo() const
 {
     std::shared_lock g(bitcoinDInfoLock);
     return bitcoinDInfo;
-}
-
-bool BitcoinDMgr::isBitcoinCore() const
-{
-    std::shared_lock g(bitcoinDInfoLock);
-    return bitcoinDInfo.isCore;
 }
 
 Version BitcoinDMgr::getBitcoinDVersion() const

--- a/src/BitcoinD.cpp
+++ b/src/BitcoinD.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -112,9 +112,6 @@ public:
     /// in the db. See also: Storage::genesisHash().
     BlockHash getBitcoinDGenesisHash() const;
 
-    /// Thread-safe.  Convenient method to avoid an extra copy. Returns getBitcoinDInfo().isCore
-    bool isBitcoinCore() const;
-
     /// Thread-safe.  Convenient method to avoid an extra copy. Returns getBitcoinDInfo().version
     Version getBitcoinDVersion() const;
 
@@ -127,10 +124,6 @@ signals:
     /// emitted if bitcoind is telling us it's still warming up (RPC error code -28). The actual warmup message is
     /// the argument.
     void inWarmUp(const QString &);
-
-    /// Emitted as soon as we read the bitcoind subversion. If it starts with /Satoshi:.., we emit this
-    /// with true, Otherwise, we emit it with false.
-    void bitcoinCoreDetection(bool);
 
     /// Emitted whenever the BitcoinDZmqNotifications change (this is also emitted the first time we retrieve them
     /// via getzmqnotifications). Note: this is never emitted if we are compiled without zmq support.

--- a/src/BitcoinD.h
+++ b/src/BitcoinD.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BitcoinD_RPCInfo.cpp
+++ b/src/BitcoinD_RPCInfo.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BitcoinD_RPCInfo.h
+++ b/src/BitcoinD_RPCInfo.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BlockProc.h
+++ b/src/BlockProc.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/BlockProcTypes.h
+++ b/src/BlockProcTypes.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ByteView.h
+++ b/src/ByteView.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/CoTask.cpp
+++ b/src/CoTask.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/CoTask.h
+++ b/src/CoTask.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Common.h
+++ b/src/Common.h
@@ -39,7 +39,7 @@ struct Exception : std::runtime_error
 struct InternalError : Exception { using Exception::Exception; ~InternalError() override; };
 struct BadArgs : Exception { using Exception::Exception; ~BadArgs() override; };
 
-#define APPNAME "Fulcrum"
+#define APPNAME "FulcrumX"
 #define VERSION "1.6.0"
 #ifdef QT_DEBUG
 inline constexpr bool isReleaseBuild() { return false; }

--- a/src/Common.h
+++ b/src/Common.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Compat.h
+++ b/src/Compat.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -112,10 +112,6 @@ protected slots:
     /// the supplied block was the next one by height).
     void on_putBlock(CtlTask *, PreProcessedBlockPtr);
 
-    /// Slot for the BitcoinDMgr::bitcoinCoreDetection. This is compared to coinIsBTC and if there is a mismatch there,
-    /// we may end up aborting the app and logging an error in this slot.
-    void on_bitcoinCoreDetection(bool); //< NB: Connected via DirectConnection an may run in the BitcoinDMgr thread!
-
 private:
     friend class CtlTask;
     /// \brief newTask - Create a specific task using this template factory function. The task will be auto-started the

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/CostCache.h
+++ b/src/CostCache.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Json/tests.cpp
+++ b/src/Json/tests.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mempool.cpp
+++ b/src/Mempool.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mempool.h
+++ b/src/Mempool.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Merkle.cpp
+++ b/src/Merkle.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Merkle.h
+++ b/src/Merkle.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mgr.cpp
+++ b/src/Mgr.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mgr.h
+++ b/src/Mgr.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mixins.cpp
+++ b/src/Mixins.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Mixins.h
+++ b/src/Mixins.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Options.h
+++ b/src/Options.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Options.h
+++ b/src/Options.h
@@ -95,8 +95,7 @@ public:
     double pollTimeSecs = defaultPollTimeSecs;
 
     /// Used for the server.donation_address RPC response. Specified via conf file only via the "donation=" variable.
-    QString donationAddress = "bitcoincash:qplw0d304x9fshz420lkvys2jxup38m9symky6k028";
-    bool isDefaultDonationAddress = true;
+    QString donationAddress = "1BCHBCH6TXBaXyc5HReLBm1sNytBF2kkPD";
     /// Used for the server.banner RPC response. Specified via conf file only via the "banner=" variable. If empty,
     /// or if the file cannot be opened, the default banner text will be emitted to the client as a fallback.
     QString bannerFile = "",

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -81,7 +81,7 @@ void PeerMgr::startup()
         throw InternalError("PeerMgr cannot be started until we have a valid genesis hash! FIXME!");
 
     const auto chain = storage->getChain(); // Note: assumption is that this is always non-empty if PeerMgr was started! (PeerMgr is never started until the db is synched so this is fine)
-    const auto lcaseCoin = storage->getCoin().trimmed().toLower();
+    const auto lcaseCoin = QString("btc");
     const auto pathPrefix = QString(":resources/%1/").arg(lcaseCoin);
     if (const auto net = BTC::NetFromName(chain); !QVector<BTC::Net>{{BTC::Net::TestNet, BTC::Net::MainNet}}.contains(net))
         // can only do peering with testnet or mainnet after they have been defined (no regtest)

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/PeerMgr.cpp
+++ b/src/PeerMgr.cpp
@@ -954,17 +954,17 @@ PeerInfoList PeerInfo::fromPeersSubscribeList(const QVariantList &l)
                 pi.protocolVersion = s;
             } else if (s.startsWith('t', Qt::CaseInsensitive)) {
                 bool ok;
-                unsigned p = s.mid(1).toUInt(&ok);
+                unsigned p = s.midRef(1).toUInt(&ok);
                 if (!p || !ok || p > std::numeric_limits<quint16>::max())
                     continue;
                 pi.tcp = quint16(p);
             } else if (s.startsWith('s', Qt::CaseInsensitive)) {
                     bool ok;
-                    unsigned p = s.mid(1).toUInt(&ok);
+                    unsigned p = s.midRef(1).toUInt(&ok);
                     if (!p || !ok || p > std::numeric_limits<quint16>::max())
                         continue;
                     pi.ssl = quint16(p);
-            } else if (s.startsWith('p', Qt::CaseInsensitive) && s.mid(1).toInt()) {
+            } else if (s.startsWith('p', Qt::CaseInsensitive) && s.midRef(1).toInt()) {
                 // skip 'p' = pruning
                 isPruning = true;
                 break;

--- a/src/PeerMgr.h
+++ b/src/PeerMgr.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RPC.cpp
+++ b/src/RPC.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RPC.h
+++ b/src/RPC.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RPCMsgId.cpp
+++ b/src/RPCMsgId.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RPCMsgId.h
+++ b/src/RPCMsgId.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RecordFile.cpp
+++ b/src/RecordFile.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RecordFile.h
+++ b/src/RecordFile.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RollingBloomFilter.cpp
+++ b/src/RollingBloomFilter.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/RollingBloomFilter.h
+++ b/src/RollingBloomFilter.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SSLCertMonitor.cpp
+++ b/src/SSLCertMonitor.cpp
@@ -88,7 +88,7 @@ void SSLCertMonitor::on_fileChanged(const QString &path)
             callOnTimerSoon(1000 /* msec */, "waitForDeletedToShowUp", [this, ct=0]() mutable {
                 ++ct;
                 QString changed, missing;
-                for (const auto &f : watchedFiles) {
+                for (const auto &f : qAsConst(watchedFiles)) {
                     const bool watched = watcher->files().contains(f);
                     const bool exists = QFile::exists(f);
                     if (exists && !watched) {

--- a/src/SSLCertMonitor.cpp
+++ b/src/SSLCertMonitor.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SSLCertMonitor.h
+++ b/src/SSLCertMonitor.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ServerMisc.h
+++ b/src/ServerMisc.h
@@ -31,7 +31,7 @@ namespace ServerMisc
     extern const Version MinProtocolVersion, MaxProtocolVersion;
 
     extern const QString AppVersion,  ///< in string form suitable for sending in protocol or banner e.g. "1.0"
-                         AppSubVersion; ///< e.g. "Fulcrum 1.0"
+                         AppSubVersion; ///< e.g. "FulcrumX 1.0"
 
     /// The amount of time we wait before initiating auto-kick when the globalSubsLimitReached signal has been asserted by a Server instance.
     inline constexpr double kMaxSubsAutoKickDelaySecs = 0.25;

--- a/src/ServerMisc.h
+++ b/src/ServerMisc.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1692,23 +1692,15 @@ void Server::rpc_blockchain_transaction_broadcast(Client *c, const RPC::BatchId 
                 // This logic is also used by the ElectronX implementations here:
                 // https://github.com/Electron-Cash/electrumx/blob/fbd00416d804c286eb7de856e9399efb07a2ceaf/electrumx/server/session.py#L1526
                 // https://github.com/Electron-Cash/electrumx/blob/fbd00416d804c286eb7de856e9399efb07a2ceaf/electrumx/lib/coins.py#L397
-                QString clientName, website;
-                if (isBTC) {
-                    clientName = "Electrum";
-                    website = "https://electrum.org/";
-                } else {
-                    clientName = "Electron Cash";
-                    website = "https://electroncash.org/";
-                }
                 ret = QString("<br/><br/>"
                               "Your transaction was successfully broadcast.<br/><br/>"
-                              "However, you are using a VULNERABLE version of %1.<br/>"
+                              "However, you are using a VULNERABLE version of Electrum.<br/>"
                               "Download the latest version from this web site ONLY:<br/>"
-                              "%2"
-                              "<br/><br/>").arg(clientName, website);
+                              "https://electrum.org/"
+                              "<br/><br/>");
                 logLine.clear();
                 QTextStream{&logLine, QIODevice::WriteOnly}
-                    << "Client " << c->id << " has a vulnerable " << clientName << " (" << uaVersion.toString()
+                    << "Client " << c->id << " has a vulnerable Electrum (" << uaVersion.toString()
                     << "); upgrade warning HTML sent to client";
                 logFilter->broadcast(true, logLine, logLine);
             }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1285,21 +1285,14 @@ void Server::rpc_blockchain_estimatefee(Client *c, const RPC::BatchId batchId, c
     QVariantList params;
     params.push_back(unsigned(n));
 
-    if (bitcoindmgr->isBitcoinCore() && bitcoindmgr->getBitcoinDVersion() >= Version{0,17,0}) {
-        // Bitcoin Core removed the "estimatefee" RPC method entirely in version 0.17.0, in favor of "estimatesmartfee"
-        generic_async_to_bitcoind(c, batchId, m.id, "estimatesmartfee", params, [](const RPC::Message &response){
-            // We don't validate what bitcoind returns. Sometimes if it has not enough information, it may
-            // return no "feerate" but instead return an "errors" entry in the dict. This is fine.
-            // ElectrumX just returns -1 in that case here, so we do the same.
-            return response.result().toMap().value("feerate", -1.0);
-        });
-        return;
-    }
-
-    // regular Bitcoin Cash daemons
-    generic_async_to_bitcoind(c, batchId, m.id, "estimatefee", params, [](const RPC::Message &response){
-        return response.result();
+    // Bitcoin Core removed the "estimatefee" RPC method entirely in version 0.17.0, in favor of "estimatesmartfee"
+    generic_async_to_bitcoind(c, batchId, m.id, "estimatesmartfee", params, [](const RPC::Message &response){
+        // We don't validate what bitcoind returns. Sometimes if it has not enough information, it may
+        // return no "feerate" but instead return an "errors" entry in the dict. This is fine.
+        // ElectrumX just returns -1 in that case here, so we do the same.
+        return response.result().toMap().value("feerate", -1.0);
     });
+    return;
 }
 void Server::rpc_blockchain_headers_subscribe(Client *c, const RPC::BatchId batchId, const RPC::Message &m) // fully implemented
 {

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -650,7 +650,7 @@ void ServerBase::applyMaxBufferToAllClients(int newMax)
         return;
     newMax = Options::clampMaxBufferSetting(newMax);
     int ctr = 0;
-    for (auto * client : clientsById) {
+    for (auto * client : qAsConst(clientsById)) {
         client->setMaxBuffer(newMax);
         ++ctr;
     }

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -2702,7 +2702,7 @@ namespace {
     void bannerfile()
     {
         const QByteArray banner(R"EOF(
-            Welcome to a Fulcrum server.
+            Welcome to a FulcrumX server.
 
             This is a test banner.
 
@@ -2731,7 +2731,7 @@ namespace {
                                                                     "/a daemon subversion nested $SERVER_VERSION/");
         const auto serverVersion = ServerMisc::AppVersion, serverSubVersion = ServerMisc::AppSubVersion;
         const auto expected1 = QString::fromUtf8(R"EOF(
-            Welcome to a Fulcrum server.
+            Welcome to a FulcrumX server.
 
             This is a test banner.
 

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -925,22 +925,6 @@ void Server::rpc_server_add_peer(Client *c, const RPC::BatchId batchId, const RP
 }
 
 namespace {
-    // In case the donation address was default, we transform it correctly to the correct network in the hopes
-    // that the author of this software (me) might get some BTC and/or BCH appropriately.
-    QString transformDefaultDonationAddressToBTCOrBCH(const Options &options, bool isBTC)
-    {
-        QString ret = options.donationAddress;
-        if (!options.isDefaultDonationAddress) return ret; // do nothing if it wasn't the default.
-        if (!ret.isEmpty()) {
-            try {
-                const BTC::Address addr(ret);
-                if (addr.isValid())
-                    ret = addr.toString(isBTC /* if BTC, then legacy, otherwise cashaddr */);
-            } catch (...) {}
-        }
-        return ret;
-    }
-
     QString performVariableSubstitutionsForBannerFile(QString && s, const QString::size_type maxBannerData,
                                                       const QString & donationAddress, const Version & daemonVersion,
                                                       const QString & daemonSubversion)
@@ -1002,7 +986,7 @@ void Server::rpc_server_banner(Client *c, const RPC::BatchId batchId, const RPC:
         const auto bitcoinDInfo = bitcoindmgr->getBitcoinDInfo();
         generic_do_async(c, batchId, m.id,
                         [bannerFile,
-                         donationAddress = transformDefaultDonationAddressToBTCOrBCH(*options, isBTC),
+                         donationAddress = options.donationAddress,
                          daemonVersion = bitcoinDInfo.version,
                          daemonSubversion = bitcoinDInfo.subversion] {
                 QVariant ret;
@@ -1025,7 +1009,7 @@ void Server::rpc_server_banner(Client *c, const RPC::BatchId batchId, const RPC:
 }
 void Server::rpc_server_donation_address(Client *c, const RPC::BatchId batchId, const RPC::Message &m)
 {
-    emit c->sendResult(batchId, m.id, transformDefaultDonationAddressToBTCOrBCH(*options, isBTC));
+    emit c->sendResult(batchId, m.id, QString("1BCHBCH6TXBaXyc5HReLBm1sNytBF2kkPD"));
 }
 /* static */
 QVariantMap Server::makeFeaturesDictForConnection(AbstractConnection *c, const QByteArray &genesisHash, const Options &opts)

--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -986,7 +986,7 @@ void Server::rpc_server_banner(Client *c, const RPC::BatchId batchId, const RPC:
         const auto bitcoinDInfo = bitcoindmgr->getBitcoinDInfo();
         generic_do_async(c, batchId, m.id,
                         [bannerFile,
-                         donationAddress = options.donationAddress,
+                         donationAddress = options->donationAddress,
                          daemonVersion = bitcoinDInfo.version,
                          daemonSubversion = bitcoinDInfo.subversion] {
                 QVariant ret;

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -302,10 +302,6 @@ protected:
     /// QTcpSocket or QSslSocket.  See getter/setter: usesWebSockets and setUsesWebSockets.  Decided by the
     /// "ws" & "wss" config file options and/or the --ws/--wss (-w/-W) CLI args.
     bool usesWS = false;
-
-    /// If true we are on the BTC chain. This is set on construction by querying Storage. Subclasses may use this
-    /// information at runtime to present RPC behavior differences between BTC vs BCH (e.g. in the address_* RPCs).
-    bool isBTC = false;
 };
 
 /// Implements the ElectrumX/ElectronX JSON-RPC protocol, version 1.4.4.
@@ -352,14 +348,6 @@ private:
     void rpc_server_peers_subscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_server_ping(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     void rpc_server_version(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    // address (resurrected in protocol 1.4.3)
-    void rpc_blockchain_address_get_balance(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_get_history(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_get_mempool(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_get_scripthash(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_listunspent(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_subscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
-    void rpc_blockchain_address_unsubscribe(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
     // blockchain misc
     void rpc_blockchain_block_header(Client *, RPC::BatchId, const RPC::Message &);  // fully implemented
     void rpc_blockchain_block_headers(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
@@ -387,7 +375,7 @@ private:
     // mempool
     void rpc_mempool_get_fee_histogram(Client *, RPC::BatchId, const RPC::Message &); // fully implemented
 
-    // Impl. for blockchain.scripthash.* & blockchain.address.* methods (both sets call into these).
+    // Impl. for blockchain.scripthash.* method.
     // Note: Validation should have already been done by caller.
     void impl_get_balance(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
     void impl_get_history(Client *, RPC::BatchId, const RPC::Message &, const HashX &scriptHash);
@@ -396,12 +384,6 @@ private:
     void impl_generic_subscribe(SubsMgr *, Client *, RPC::BatchId, const RPC::Message &, const HashX &key,
                                 const std::optional<QString> & aliasUsedForNotifications = {});
     void impl_generic_unsubscribe(SubsMgr *, Client *, RPC::BatchId, const RPC::Message &, const HashX &key);
-    /// Commonly used by above methods.  Takes the first address argument in the m.paramsList() and converts it to
-    /// a scripthash, returning the raw bytes.  Will throw RPCError on invalid argument.
-    /// It is assumed the caller already ensured m.paramsList() has at least 1 item in it (which the RPC machinery
-    /// does normally if the params spec is correctly written).  Validation is done on the argument, however, and
-    /// it will throw RPCError in all parse/failure cases and only ever returns a valid scripthash on success.
-    HashX parseFirstAddrParamToShCommon(const RPC::Message &m, QString *addrStrOut = nullptr) const;
     /// Commonly used by above methods.  Takes the first hex argument in the m.paramsList() and hes decodes it to
     /// a hash, returning the raw bytes.  Will throw RPCError on invalid argument. The error will be
     /// "Invalid scripthash" unless errMsg is specified, in which case it will be errMsg.

--- a/src/Servers.h
+++ b/src/Servers.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SrvMgr.cpp
+++ b/src/SrvMgr.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SrvMgr.h
+++ b/src/SrvMgr.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2082,12 +2082,6 @@ void Storage::setChain(const QString &chain)
     save(SaveItem::Meta);
 }
 
-QString Storage::getCoin() const
-{
-    SharedLockGuard l(p->metaLock);
-    return p->meta.coin;
-}
-
 void Storage::setCoin(const QString &coin) {
     {
         ExclusiveLockGuard l(p->metaLock);

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -3976,7 +3976,7 @@ namespace {
                         } else {
                             // Older db's pre-1.3.0 lacked this field -- but now we interpret missing data here as
                             // "BCH" (since all older db's were always BCH only).
-                            m.coin = BTC::coinToName(BTC::Coin::BCH);
+                            m.coin = BTC::coinToName(BTC::Coin::BTC);
                             Debug() << "Missing coin info from Meta table, defaulting coin to: \"" << m.coin << "\"";
                         }
                     }

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -131,9 +131,6 @@ public:
     QString getChain() const;
     void setChain(const QString &); // implicitly calls db save of 'meta' (thread safe)
 
-    /// Will be one of: "BCH", "BTC" or "" on a newly initialized DB. Note Controller class must use this to match
-    /// the coin with the bitcoind it is connected to.  It sets the Coin via setCoin on first connection to a bitcoind.
-    QString getCoin() const;
     /// Controller calls this the first time it connects to a bitcoind if the current coin is Coin::Unknown in order
     /// to save the Coin to the DB.
     void setCoin(const QString &); // implicitly calls db save of 'meta' (thread safe)

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SubStatus.cpp
+++ b/src/SubStatus.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SubStatus.h
+++ b/src/SubStatus.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SubsMgr.cpp
+++ b/src/SubsMgr.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/SubsMgr.h
+++ b/src/SubsMgr.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/TXO.cpp
+++ b/src/TXO.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/TXO.h
+++ b/src/TXO.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/TXO_Compact.h
+++ b/src/TXO_Compact.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadPool.h
+++ b/src/ThreadPool.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ThreadSafeHashTable.h
+++ b/src/ThreadSafeHashTable.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Util.h
+++ b/src/Util.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/VarInt.cpp
+++ b/src/VarInt.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/VarInt.h
+++ b/src/VarInt.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ZmqSubNotifier.cpp
+++ b/src/ZmqSubNotifier.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/ZmqSubNotifier.h
+++ b/src/ZmqSubNotifier.h
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/bitcoin/amount.cpp
+++ b/src/bitcoin/amount.cpp
@@ -15,7 +15,7 @@ namespace bitcoin {
 
 // added by Calin
 namespace {
-std::string mutableCurrencyUnit = "BCH";
+std::string mutableCurrencyUnit = "BTC";
 std::shared_mutex currencyUnitMut;
 }
 void SetCurrencyUnit(const std::string &unit) {

--- a/src/bitcoin/test.cpp
+++ b/src/bitcoin/test.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/src/register_MetaTypes.cpp
+++ b/src/register_MetaTypes.cpp
@@ -1,6 +1,7 @@
 //
-// Fulcrum - A fast & nimble SPV Server for Bitcoin Cash
+// FulcrumX - A fast & nimble SPV Server for Bitcoin
 // Copyright (C) 2019-2022 Calin A. Culianu <calin.culianu@gmail.com>
+// Copyright (C) 2022 Aaron Dewes <aaron.dewes@protonmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Thanks for this fork, I was reading through the README and figured I'd update some of these references only relevant to upstream Fulcrum.